### PR TITLE
优化key前缀统计的处理逻辑，Counter配置统一管理

### DIFF
--- a/dump/counter.go
+++ b/dump/counter.go
@@ -23,8 +23,49 @@ import (
 	"github.com/919927181/rdr/decoder"
 )
 
+const (
+	DefaultSeparators = ":;,_- "
+	DefaultTopKeyNum  = 500
+
+	// 大约 99% 的key前缀为低频
+	DefaultStoreAllPrefixes        = false
+	DefaultTopPrefixNum            = 500
+	DefaultPrefixPreShrinkNum      = 5000
+	DefaultPrefixContainerCapacity = 50000
+)
+
+type CounterConfig struct {
+	// 分隔符，默认 ":;,_- "
+	Separators string
+	// 仅在内存足够时开启，默认关闭
+	StoreAllPrefixes bool
+	// Bigkey数量阈值，默认 500
+	TopKeyNum int
+	// 前缀数量阈值，默认 500
+	TopPrefixNum int
+	// 前缀容器容量
+	PrefixContainerCapacity int
+	// 前缀预缩容数量
+	PrefixPreShrinkNum int
+}
+
+// 默认配置
+func NewCounterConfig() *CounterConfig {
+	return &CounterConfig{
+		Separators:              DefaultSeparators,
+		StoreAllPrefixes:        DefaultStoreAllPrefixes,
+		TopKeyNum:               DefaultTopKeyNum,
+		TopPrefixNum:            DefaultTopPrefixNum,
+		PrefixContainerCapacity: DefaultPrefixContainerCapacity,
+		PrefixPreShrinkNum:      DefaultPrefixPreShrinkNum,
+	}
+}
+
 // NewCounter return a pointer of Counter
-func NewCounter() *Counter {
+func NewCounter(config *CounterConfig) *Counter {
+	if config == nil {
+		config = NewCounterConfig()
+	}
 	h := &entryHeap{}
 	heap.Init(h)
 	p := &prefixHeap{}
@@ -43,10 +84,10 @@ func NewCounter() *Counter {
 		keyPrefixNum:       map[typeKey]uint64{},
 		typeBytes:          map[string]uint64{},
 		typeNum:            map[string]uint64{},
-		separators:         ":;,_- ",
 		slotBytes:          map[int]uint64{},
 		slotNum:            map[int]uint64{},
 		keyPrefixDb:        map[typeKey]string{},
+		config:             config,
 	}
 }
 
@@ -63,12 +104,12 @@ type Counter struct {
 	lengthLevelNum     map[typeKey]uint64
 	keyPrefixBytes     map[typeKey]uint64
 	keyPrefixNum       map[typeKey]uint64
-	separators         string
 	typeBytes          map[string]uint64
 	typeNum            map[string]uint64
 	slotBytes          map[int]uint64
 	slotNum            map[int]uint64
 	keyPrefixDb        map[typeKey]string
+	config             *CounterConfig
 }
 
 // Count by various dimensions，show.go NewCounter 后，调用此方法，遍历decoder的entry, <-chan表示一个只能接收数据的单向通道
@@ -77,7 +118,7 @@ func (c *Counter) Count(in <-chan *decoder.Entry) {
 		c.count(e)
 	}
 	// get largest prefixes
-	c.calcuLargestKeyPrefix(1000)
+	c.calcuLargestKeyPrefix(c.config.TopPrefixNum)
 }
 
 // 传入一个entry，执行各指标的count方法
@@ -90,7 +131,7 @@ func (c *Counter) count(e *decoder.Entry) {
 	//c.countByDb(e) //该方法由caiqing0204添加
 }
 
-//该方法由caiqing0204添加，没有看到哪儿用到，这里会导致前缀所属db不正确
+// 该方法由caiqing0204添加，没有看到哪儿用到，这里会导致前缀所属db不正确
 func (c *Counter) countByDb(e *decoder.Entry) {
 	key := typeKey{
 		Type: e.Type,
@@ -108,10 +149,10 @@ func (c *Counter) GetLargestEntries(num int, sizeFilter int64) []*decoder.Entry 
 		entries := *c.largestEntries
 		// 阈值默认为0，当大于0时，将过滤掉小于阈值的key
 		if sizeFilter > 0 {
-			if  entries[i].Bytes > uint64(sizeFilter) {
+			if entries[i].Bytes > uint64(sizeFilter) {
 				res = append(res, entries[i])
 			}
-		}else {
+		} else {
 			res = append(res, entries[i])
 		}
 	}
@@ -151,7 +192,6 @@ func (c *Counter) GetLenLevelCount() []*PrefixEntry {
 	}
 	return res
 }
-
 
 func (c *Counter) countLargestEntries(e *decoder.Entry, num int) {
 	heap.Push(c.largestEntries, e)
@@ -206,9 +246,8 @@ func (c *Counter) countByKeyPrefix(e *decoder.Entry) {
 		return c
 	}, e.Key)
 
-
-    // 将key名字进行分割，得到所有前缀
-	prefixes := getPrefixes(k, c.separators)
+	// 将key名字进行分割，得到所有前缀
+	prefixes := getPrefixes(k, c.config.Separators)
 	key := typeKey{
 		Type: e.Type,
 	}
@@ -220,14 +259,18 @@ func (c *Counter) countByKeyPrefix(e *decoder.Entry) {
 		key.Key = prefix
 		c.keyPrefixBytes[key] += e.Bytes
 		c.keyPrefixNum[key]++
-		 //2025-12-25 liyanjing add 如果不同db里有相同前缀的key，那么设置属于任何一个db都不合适
-		if c.keyPrefixDb[key] =="" {
+		//2025-12-25 liyanjing add 如果不同db里有相同前缀的key，那么设置属于任何一个db都不合适
+		if c.keyPrefixDb[key] == "" {
 			c.keyPrefixDb[key] = strconv.Itoa(e.Db)
-		}else {
+		} else {
 			if !strings.Contains(c.keyPrefixDb[key], strconv.Itoa(e.Db)) {
-				c.keyPrefixDb[key] += ","+strconv.Itoa(e.Db)
+				c.keyPrefixDb[key] += "," + strconv.Itoa(e.Db)
 			}
 		}
+	}
+	// 如果不开存储所有前缀，并且前缀数量超过容器容量，则进行缩容
+	if !c.config.StoreAllPrefixes && len(c.keyPrefixBytes) > c.config.PrefixContainerCapacity {
+		c.calcuLargestKeyPrefix(c.config.PrefixPreShrinkNum)
 	}
 }
 
@@ -240,6 +283,8 @@ func (c *Counter) countBySlot(e *decoder.Entry) {
 }
 
 func (c *Counter) calcuLargestKeyPrefix(num int) {
+	tempPrefixes := &prefixHeap{}
+	heap.Init(tempPrefixes)
 	for key := range c.keyPrefixBytes {
 		k := &PrefixEntry{}
 		k.Type = key.Type
@@ -250,12 +295,20 @@ func (c *Counter) calcuLargestKeyPrefix(num int) {
 		delete(c.keyPrefixBytes, key)
 		delete(c.keyPrefixNum, key)
 
-		heap.Push(c.largestKeyPrefixes, k)
-		l := c.largestKeyPrefixes.Len()
+		heap.Push(tempPrefixes, k)
+		l := tempPrefixes.Len()
 		if l > num {
-			heap.Pop(c.largestKeyPrefixes)
+			heap.Pop(tempPrefixes)
 		}
 	}
+	for i := 0; i < tempPrefixes.Len(); i++ {
+		entries := *tempPrefixes
+
+		// save
+		c.keyPrefixBytes[entries[i].typeKey] = entries[i].Bytes
+		c.keyPrefixNum[entries[i].typeKey] = entries[i].Num
+	}
+	c.largestKeyPrefixes = tempPrefixes
 }
 
 type entryHeap []*decoder.Entry
@@ -294,7 +347,7 @@ type PrefixEntry struct {
 	typeKey
 	Bytes uint64
 	Num   uint64
-	Db    string  //之前为int
+	Db    string //之前为int
 }
 
 func (h prefixHeap) Len() int {

--- a/dump/counter_test.go
+++ b/dump/counter_test.go
@@ -31,9 +31,8 @@ func TestGetLargestKeyPrefixes(t *testing.T) {
 		LenOfLargestElem:   1,
 		FieldOfLargestElem: "test",
 		Db:                 0,
-
 	}
-	c := NewCounter()
+	c := NewCounter(NewCounterConfig())
 	c.countByKeyPrefix(e)
 	c.calcuLargestKeyPrefix(1)
 	for _, p := range c.GetLargestKeyPrefixes() {

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -20,8 +20,8 @@ import (
 
 // Dump rdb file statistical information, 此方法不再用了，因为有了输出到STDOUT 或 file
 func Dump(path string) (map[string]interface{}, error) {
-	topN := 300      // top N bigkey (按内存),最大500
-	sizeFilter := 0  // GetLargestEntries 过滤掉小于阈值的key，传0表示不过滤
+	topN := 300     // top N bigkey (按内存),最大500
+	sizeFilter := 0 // GetLargestEntries 过滤掉小于阈值的key，传0表示不过滤
 
 	var data map[string]interface{}
 	decoder := decoder.NewDecoder()
@@ -38,7 +38,7 @@ func Dump(path string) (map[string]interface{}, error) {
 			return
 		}
 	}()
-	cnt := NewCounter()
+	cnt := NewCounter(NewCounterConfig())
 	cnt.Count(decoder.Entries)
 	filename := filepath.Base(path)
 	data = GetData(filename, cnt, topN, int64(sizeFilter))
@@ -51,8 +51,8 @@ func ToCliWriter(cli *cli.Context) {
 		fmt.Fprintln(cli.App.ErrWriter, " requires at least 1 argument")
 		return
 	}
-	topN := 100      // top N bigkey (按内存),最大500
-	sizeFilter := 0  // GetLargestEntries 过滤掉小于阈值的key，传0表示不过滤
+	topN := 100     // top N bigkey (按内存),最大500
+	sizeFilter := 0 // GetLargestEntries 过滤掉小于阈值的key，传0表示不过滤
 
 	// parse rdb file
 	fmt.Fprintln(cli.App.Writer, "[")
@@ -61,7 +61,7 @@ func ToCliWriter(cli *cli.Context) {
 		file := cli.Args().Get(i)
 		rdbDecoder := decoder.NewDecoder()
 		go Decode(cli, rdbDecoder, file)
-		cnt := NewCounter()
+		cnt := NewCounter(NewCounterConfig())
 		cnt.Count(rdbDecoder.Entries)
 		filename := filepath.Base(file)
 		data := GetData(filename, cnt, topN, int64(sizeFilter))
@@ -85,17 +85,38 @@ func ToCliWriterToFile(cli *cli.Context) {
 		return
 	}
 
-    // top N bigkey (按内存), 最大500
+	// top N bigkey (按内存)
 	topN := cli.Int("num")
-    if topN > 500 {
-		fmt.Fprintln(cli.App.ErrWriter, " Please pass a number less than 500!")
-		return
-	}
 	// 将带单位的字符串转换为字节数, GetLargestEntries 过滤掉小于阈值sizeFilter的key，传0表示不过滤
 	sizeFilter, err := ParseUnitToBytes(cli.String("size"))
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
+	}
+
+	// Store all prefixes
+	storeAllPrefixes := cli.Bool("store-all-prefixes")
+
+	// Separators
+	separators := cli.String("separators")
+
+	// Top prefixes
+	topPrefixs := cli.Int("top-prefixs")
+
+	// Prefix shrink
+	prefixShrink := cli.Int("prefix-shrink")
+
+	// Prefix capacity
+	prefixCapacity := cli.Int("prefix-capacity")
+
+	// Counter config
+	counterConfig := &CounterConfig{
+		StoreAllPrefixes:        storeAllPrefixes,
+		Separators:              separators,
+		TopPrefixNum:            topPrefixs,
+		TopKeyNum:               topN,
+		PrefixPreShrinkNum:      prefixShrink,
+		PrefixContainerCapacity: prefixCapacity,
 	}
 
 	cst := time.FixedZone("CST", 8*60*60)
@@ -126,7 +147,7 @@ func ToCliWriterToFile(cli *cli.Context) {
 		rdb_file := cli.Args().Get(i)
 		rdbDecoder := decoder.NewDecoder()
 		go Decode(cli, rdbDecoder, rdb_file)
-		cnt := NewCounter()
+		cnt := NewCounter(counterConfig)
 		cnt.Count(rdbDecoder.Entries)
 		filename := filepath.Base(rdb_file)
 		data := GetData(filename, cnt, topN, sizeFilter)

--- a/dump/show.go
+++ b/dump/show.go
@@ -53,17 +53,37 @@ func Show(c *cli.Context) {
 		return
 	}
 
-	// top N bigkey (按内存), 最大500
+	// top N bigkey (按内存)
 	topN := c.Int("num")
-	if topN > 500 {
-		fmt.Fprintln(c.App.Writer, " Please pass a number less than 500!")
-		return
-	}
 	// 将带单位的字符串转换为字节数, GetLargestEntries 过滤掉小于阈值sizeFilter的key，传0表示不过滤
 	sizeFilter, err := ParseUnitToBytes(c.String("size"))
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
+	}
+	// Store all prefixes
+	storeAllPrefixes := c.Bool("store-all-prefixes")
+
+	// Separators
+	separators := c.String("separators")
+
+	// Top prefixes
+	topPrefixs := c.Int("top-prefixs")
+
+	// Prefix shrink
+	prefixShrink := c.Int("prefix-shrink")
+
+	// Prefix capacity
+	prefixCapacity := c.Int("prefix-capacity")
+
+	// Counter config
+	counterConfig := &CounterConfig{
+		StoreAllPrefixes:        storeAllPrefixes,
+		Separators:              separators,
+		TopPrefixNum:            topPrefixs,
+		TopKeyNum:               topN,
+		PrefixPreShrinkNum:      prefixShrink,
+		PrefixContainerCapacity: prefixCapacity,
 	}
 
 	// parse rdbfile
@@ -82,7 +102,7 @@ func Show(c *cli.Context) {
 						start_milliseconds := time.Now().UnixMilli()
 						fmt.Fprintf(c.App.Writer, "start to parse %v \n", filename)
 						go Decode(c, decoder, v)
-						counter := NewCounter()
+						counter := NewCounter(counterConfig)
 						counter.Count(decoder.Entries)
 						counters.Set(filename, counter)
 						end_milliseconds := time.Now().UnixMilli()
@@ -92,7 +112,7 @@ func Show(c *cli.Context) {
 						// init common data in template
 						tplCommonData["Instances"] = instances
 						tplCommonData["TopN"] = strconv.Itoa(topN)
-						tplCommonData["sizeFilter"] = strconv.FormatInt(sizeFilter,10)
+						tplCommonData["sizeFilter"] = strconv.FormatInt(sizeFilter, 10)
 					}
 				}
 

--- a/main.go
+++ b/main.go
@@ -27,7 +27,6 @@ import (
 //go:generate go-bindata -prefix "static/" -o=static/static.go -pkg=static -ignore static.go static/...
 //go:generate go-bindata -prefix "views/" -o=views/views.go -pkg=views -ignore views.go views/...
 
-
 func main() {
 	app := cli.NewApp()
 	app.Name = "rdr"
@@ -57,8 +56,32 @@ func main() {
 					Value: "0kb",
 					Usage: " when GetLargestEntries, keys smaller than the threshold are filtered. supported units is B/KB/MB/GB, and can be lowercase",
 				},
+				cli.BoolFlag{
+					Name:  "store-all-prefixes, spa",
+					Usage: " store all key prefixes, default is false",
+				},
+				cli.StringFlag{
+					Name:  "separators, sep",
+					Value: ":;,_- ",
+					Usage: " separators for key prefixes, default is :;,_- ",
+				},
+				cli.IntFlag{
+					Name:  "top-prefixs, tpn",
+					Value: 500,
+					Usage: " top N key prefixes, default is 500",
+				},
+				cli.IntFlag{
+					Name:  "prefix-shrink, psn",
+					Value: 5000,
+					Usage: " prefix shrink num, default is 5000",
+				},
+				cli.IntFlag{
+					Name:  "prefix-capacity, pc",
+					Value: 50000,
+					Usage: " prefix container capacity, default is 50000",
+				},
 			},
-			Action:    dump.ToCliWriterToFile,
+			Action: dump.ToCliWriterToFile,
 		},
 		{
 			Name:      "show",
@@ -79,6 +102,30 @@ func main() {
 					Name:  "size, s",
 					Value: "0kb",
 					Usage: " when GetLargestEntries, keys smaller than the threshold are filtered. supported units is B/KB/MB/GB, and can be lowercase",
+				},
+				cli.BoolFlag{
+					Name:  "store-all-prefixes, spa",
+					Usage: " store all key prefixes, default is false",
+				},
+				cli.StringFlag{
+					Name:  "separators, sep",
+					Value: ":;,_- ",
+					Usage: " separators for key prefixes, default is :;,_- ",
+				},
+				cli.IntFlag{
+					Name:  "top-prefixs, tpn",
+					Value: 500,
+					Usage: " top N key prefixes, default is 500",
+				},
+				cli.IntFlag{
+					Name:  "prefix-shrink, psn",
+					Value: 5000,
+					Usage: " prefix shrink num, default is 5000",
+				},
+				cli.IntFlag{
+					Name:  "prefix-capacity, pc",
+					Value: 50000,
+					Usage: " prefix container capacity, default is 50000",
 				},
 			},
 			Action: dump.Show,


### PR DESCRIPTION
### 优化key前缀统计的处理逻辑

**1. 增加配置项**
- 是否存储全量key前缀的配置选项
- key前缀数量
- key前缀容器大小
- key前缀缩容数量


**2. key前缀处理优化**

> 具体处理逻辑 https://github.com/919927181/rdr/issues/1#issuecomment-4059149375

当不为存储全量key前缀时，在key前缀统计过程中，当key前缀数量达到容器上限时，会进行缩容，会对低频的key前缀进行提前处理，避免因key前缀数量的不确定性导致的内存爆炸问题。

### 配置统一处理
将Counter的配置封装在CounterConfig中，目前包括前缀处理的几个配置加上大key数量TopBigKeyNum和前缀分割符Separators，在新建Counter时应用传入的config，若为nil，应用默认的config。

考虑到这个更多是打包为可执行程序使用，若后续会更多作为第三方包的话感觉可以转为option模式进行配置处理